### PR TITLE
fix method name in destroy hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default class UpdatePlugin extends Phaser.Plugins.ScenePlugin {
   sceneDestroy () {
     const events = this.systems.events;
 
-    events.off('update', this.scenePostUpdate, this);
+    events.off('update', this.sceneUpdate, this);
     events.off('shutdown', this.sceneShutdown, this);
     events.off('destroy', this.sceneDestroy, this);
 


### PR DESCRIPTION
Upon translating your solution to TypeScript, I found the method name was misspelled in the destroy hook.